### PR TITLE
fix: Defined BundleCreateResponse for createBundle API

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -636,7 +636,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/BundleCreateResponse"
                 }
               }
             },
@@ -6360,6 +6360,9 @@
             "format": "date"
           }
         }
+      },
+      "BundleCreateResponse": {
+        "type": "object"
       },
       "BundlePaymentType": {
         "type": "object",

--- a/src/main/java/it/pagopa/selfcare/pagopa/backoffice/client/GecClient.java
+++ b/src/main/java/it/pagopa/selfcare/pagopa/backoffice/client/GecClient.java
@@ -34,7 +34,7 @@ public interface GecClient {
 
     @PostMapping(value = "/psps/{idpsp}/bundles", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
-    String createPSPBundle(@PathVariable(required = true) String idpsp,
+    BundleCreateResponse createPSPBundle(@PathVariable(required = true) String idpsp,
                            @RequestBody @NotNull BundleRequest bundle);
 
     @GetMapping(value = "/paymenttypes", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/it/pagopa/selfcare/pagopa/backoffice/controller/CommissionBundleController.java
+++ b/src/main/java/it/pagopa/selfcare/pagopa/backoffice/controller/CommissionBundleController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.*;
+import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.client.BundleCreateResponse;
 import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.client.BundleRequest;
 import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.client.BundleType;
 import it.pagopa.selfcare.pagopa.backoffice.service.CommissionBundleService;
@@ -64,8 +65,8 @@ public class CommissionBundleController {
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "Create a commissional bundle related to PSP", security = {@SecurityRequirement(name = "JWT")})
     @OpenApiTableMetadata
-    public String createBundle(@Parameter(description = "Fiscal code of the payment service provider") @PathVariable("psp-code") String pspCode,
-                               @Parameter(description = "Commissional bundle related to PSP to be created") @RequestBody @NotNull BundleRequest bundleRequest) {
+    public BundleCreateResponse createBundle(@Parameter(description = "Fiscal code of the payment service provider") @PathVariable("psp-code") String pspCode,
+                                             @Parameter(description = "Commissional bundle related to PSP to be created") @RequestBody @NotNull BundleRequest bundleRequest) {
 
         return commissionBundleService.createPSPBundle(pspCode, bundleRequest);
     }

--- a/src/main/java/it/pagopa/selfcare/pagopa/backoffice/model/commissionbundle/client/BundleCreateResponse.java
+++ b/src/main/java/it/pagopa/selfcare/pagopa/backoffice/model/commissionbundle/client/BundleCreateResponse.java
@@ -2,4 +2,8 @@ package it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.client;
 
 public class BundleCreateResponse {
     private String idBundle;
+
+    public BundleCreateResponse(String idBundle) {
+        this.idBundle = idBundle;
+    }
 }

--- a/src/main/java/it/pagopa/selfcare/pagopa/backoffice/model/commissionbundle/client/BundleCreateResponse.java
+++ b/src/main/java/it/pagopa/selfcare/pagopa/backoffice/model/commissionbundle/client/BundleCreateResponse.java
@@ -1,9 +1,8 @@
 package it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.client;
 
+import lombok.Data;
+
+@Data
 public class BundleCreateResponse {
     private String idBundle;
-
-    public BundleCreateResponse(String idBundle) {
-        this.idBundle = idBundle;
-    }
 }

--- a/src/main/java/it/pagopa/selfcare/pagopa/backoffice/model/commissionbundle/client/BundleCreateResponse.java
+++ b/src/main/java/it/pagopa/selfcare/pagopa/backoffice/model/commissionbundle/client/BundleCreateResponse.java
@@ -1,0 +1,5 @@
+package it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.client;
+
+public class BundleCreateResponse {
+    private String idBundle;
+}

--- a/src/main/java/it/pagopa/selfcare/pagopa/backoffice/service/CommissionBundleService.java
+++ b/src/main/java/it/pagopa/selfcare/pagopa/backoffice/service/CommissionBundleService.java
@@ -34,7 +34,7 @@ public class CommissionBundleService {
         return gecClient.getBundlesByPSP(pspCode, bundleType, name, limit, page);
     }
 
-    public String createPSPBundle(String pspCode, BundleRequest bundle) {
+    public BundleCreateResponse createPSPBundle(String pspCode, BundleRequest bundle) {
         return gecClient.createPSPBundle(pspCode, bundle);
     }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- Introduced BundleCreateResponse for createBundle api
- Updated openapi specs

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Changed createBundle response from String to BundleCreateResponse obj because type mismatch with gec api

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
