### PR TITLE
 [VAS-806] feat: Add private bundle recipient table API

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -2044,7 +2044,7 @@
             }
           },
           {
-            "description": "Commission bundle's type",
+            "description": "Commission bundle's type (Required only for subscription with status WAITING",
             "in": "query",
             "name": "bundleType",
             "required": false,
@@ -2203,7 +2203,7 @@
             "JWT": []
           }
         ],
-        "summary": "Get a paginated list of creditor institution's subscriptions to a public bundle of a PSP",
+        "summary": "Get a paginated list of creditor institution's subscriptions to a public/private bundle of a PSP",
         "tags": [
           "Commission bundles"
         ]
@@ -2252,7 +2252,7 @@
             }
           },
           {
-            "description": "Commission bundle's type",
+            "description": "Commission bundle's type (Required only for subscription with status WAITING",
             "in": "query",
             "name": "bundleType",
             "required": false,

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -2020,358 +2020,10 @@
         ]
       }
     },
-    "/bundles/{id-bundle}/payment-service-providers/{psp-tax-code}/recipients": {
-      "get": {
-        "description": "Internal | External | Synchronous | Authorization | Authentication | TPS | Idempotency | Stateless | Read/Write Intense | Cacheable\n-|-|-|-|-|-|-|-|-|-\nY | N | Y | JWT | JWT | 1.0/sec | Y | Y | Read | N\n",
-        "operationId": "getPrivateBundleCIRecipients",
-        "parameters": [
-          {
-            "description": "Commission bundle's id",
-            "in": "path",
-            "name": "id-bundle",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Payment Service Provider's tax code",
-            "in": "path",
-            "name": "psp-tax-code",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Subscription status",
-            "in": "query",
-            "name": "status",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "WAITING",
-                "ACCEPTED"
-              ]
-            }
-          },
-          {
-            "description": "Creditor Institution's tax code, used for filtering results",
-            "in": "query",
-            "name": "ciTaxCode",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Number of elements in one page",
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 50
-            }
-          },
-          {
-            "description": "Page number",
-            "in": "query",
-            "name": "page",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 0
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CIBundleSubscriptionsResource"
-                }
-              }
-            },
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            },
-            "description": "Bad Request",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            },
-            "description": "Not found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            },
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "JWT": []
-          }
-        ],
-        "summary": "Get a paginated list of creditor institution recipients of a private bundle of a PSP",
-        "tags": [
-          "Commission bundles"
-        ]
-      },
-      "parameters": [
-        {
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "in": "header",
-          "name": "X-Request-Id",
-          "schema": {
-            "type": "string"
-          }
-        }
-      ]
-    },
-    "/bundles/{id-bundle}/payment-service-providers/{psp-tax-code}/recipients/{ci-tax-code}": {
-      "get": {
-        "description": "Internal | External | Synchronous | Authorization | Authentication | TPS | Idempotency | Stateless | Read/Write Intense | Cacheable\n-|-|-|-|-|-|-|-|-|-\nY | N | Y | JWT | JWT | 1.0/sec | Y | Y | Read | N\n",
-        "operationId": "getPrivateBundleCIRecipientDetail",
-        "parameters": [
-          {
-            "description": "Commission bundle's id",
-            "in": "path",
-            "name": "id-bundle",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Payment Service Provider's tax code",
-            "in": "path",
-            "name": "psp-tax-code",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Creditor institution's tax code",
-            "in": "path",
-            "name": "ci-tax-code",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Subscription status",
-            "in": "query",
-            "name": "status",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "WAITING",
-                "ACCEPTED"
-              ]
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CIBundleSubscriptionsDetail"
-                }
-              }
-            },
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            },
-            "description": "Bad Request",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            },
-            "description": "Not found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            },
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "JWT": []
-          }
-        ],
-        "summary": "Get the detail of a creditor institution recipient of a private bundle of a PSP",
-        "tags": [
-          "Commission bundles"
-        ]
-      },
-      "parameters": [
-        {
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "in": "header",
-          "name": "X-Request-Id",
-          "schema": {
-            "type": "string"
-          }
-        }
-      ]
-    },
     "/bundles/{id-bundle}/payment-service-providers/{psp-tax-code}/subscriptions": {
       "get": {
         "description": "Internal | External | Synchronous | Authorization | Authentication | TPS | Idempotency | Stateless | Read/Write Intense | Cacheable\n-|-|-|-|-|-|-|-|-|-\nY | N | Y | JWT | JWT | 1.0/sec | Y | Y | Read | N\n",
-        "operationId": "getPublicBundleCISubscriptions",
+        "operationId": "getBundleCISubscriptions",
         "parameters": [
           {
             "description": "Commission bundle's id",
@@ -2389,6 +2041,20 @@
             "required": true,
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "description": "Commission bundle's type",
+            "in": "query",
+            "name": "bundleType",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "GLOBAL",
+                "PUBLIC",
+                "PRIVATE"
+              ]
             }
           },
           {
@@ -2556,7 +2222,7 @@
     "/bundles/{id-bundle}/payment-service-providers/{psp-tax-code}/subscriptions/{ci-tax-code}": {
       "get": {
         "description": "Internal | External | Synchronous | Authorization | Authentication | TPS | Idempotency | Stateless | Read/Write Intense | Cacheable\n-|-|-|-|-|-|-|-|-|-\nY | N | Y | JWT | JWT | 1.0/sec | Y | Y | Read | N\n",
-        "operationId": "getPublicBundleCISubscriptionsDetail",
+        "operationId": "getBundleCISubscriptionsDetail",
         "parameters": [
           {
             "description": "Commission bundle's id",
@@ -2583,6 +2249,20 @@
             "required": true,
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "description": "Commission bundle's type",
+            "in": "query",
+            "name": "bundleType",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "GLOBAL",
+                "PUBLIC",
+                "PRIVATE"
+              ]
             }
           },
           {
@@ -2700,7 +2380,7 @@
             "JWT": []
           }
         ],
-        "summary": "Get the detail of a creditor institution's subscription to a public bundle of a PSP",
+        "summary": "Get the detail of a creditor institution's subscription to a public/private bundle of a PSP",
         "tags": [
           "Commission bundles"
         ]
@@ -11616,6 +11296,10 @@
             "type": "string",
             "description": "CI info"
           },
+          "logo": {
+            "type": "string",
+            "description": "Existing logo url"
+          },
           "organization": {
             "type": "string",
             "description": "CI organization unit managing the payment "
@@ -11631,6 +11315,10 @@
           "posteAuth": {
             "type": "string",
             "description": "Poste auth code"
+          },
+          "posteNane": {
+            "type": "string",
+            "description": "Poste name"
           },
           "taxCode": {
             "type": "string",

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -2020,6 +2020,354 @@
         ]
       }
     },
+    "/bundles/{id-bundle}/payment-service-providers/{psp-tax-code}/recipients": {
+      "get": {
+        "description": "Internal | External | Synchronous | Authorization | Authentication | TPS | Idempotency | Stateless | Read/Write Intense | Cacheable\n-|-|-|-|-|-|-|-|-|-\nY | N | Y | JWT | JWT | 1.0/sec | Y | Y | Read | N\n",
+        "operationId": "getPrivateBundleCIRecipients",
+        "parameters": [
+          {
+            "description": "Commission bundle's id",
+            "in": "path",
+            "name": "id-bundle",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Payment Service Provider's tax code",
+            "in": "path",
+            "name": "psp-tax-code",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Subscription status",
+            "in": "query",
+            "name": "status",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "WAITING",
+                "ACCEPTED"
+              ]
+            }
+          },
+          {
+            "description": "Creditor Institution's tax code, used for filtering results",
+            "in": "query",
+            "name": "ciTaxCode",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of elements in one page",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 50
+            }
+          },
+          {
+            "description": "Page number",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CIBundleSubscriptionsResource"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            },
+            "description": "Bad Request",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            },
+            "description": "Not found",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            },
+            "description": "Service unavailable",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "JWT": []
+          }
+        ],
+        "summary": "Get a paginated list of creditor institution recipients of a private bundle of a PSP",
+        "tags": [
+          "Commission bundles"
+        ]
+      },
+      "parameters": [
+        {
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "in": "header",
+          "name": "X-Request-Id",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/bundles/{id-bundle}/payment-service-providers/{psp-tax-code}/recipients/{ci-tax-code}": {
+      "get": {
+        "description": "Internal | External | Synchronous | Authorization | Authentication | TPS | Idempotency | Stateless | Read/Write Intense | Cacheable\n-|-|-|-|-|-|-|-|-|-\nY | N | Y | JWT | JWT | 1.0/sec | Y | Y | Read | N\n",
+        "operationId": "getPrivateBundleCIRecipientDetail",
+        "parameters": [
+          {
+            "description": "Commission bundle's id",
+            "in": "path",
+            "name": "id-bundle",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Payment Service Provider's tax code",
+            "in": "path",
+            "name": "psp-tax-code",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Creditor institution's tax code",
+            "in": "path",
+            "name": "ci-tax-code",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Subscription status",
+            "in": "query",
+            "name": "status",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "WAITING",
+                "ACCEPTED"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CIBundleSubscriptionsDetail"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            },
+            "description": "Bad Request",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            },
+            "description": "Not found",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            },
+            "description": "Service unavailable",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "JWT": []
+          }
+        ],
+        "summary": "Get the detail of a creditor institution recipient of a private bundle of a PSP",
+        "tags": [
+          "Commission bundles"
+        ]
+      },
+      "parameters": [
+        {
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "in": "header",
+          "name": "X-Request-Id",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
     "/bundles/{id-bundle}/payment-service-providers/{psp-tax-code}/subscriptions": {
       "get": {
         "description": "Internal | External | Synchronous | Authorization | Authentication | TPS | Idempotency | Stateless | Read/Write Intense | Cacheable\n-|-|-|-|-|-|-|-|-|-\nY | N | Y | JWT | JWT | 1.0/sec | Y | Y | Read | N\n",
@@ -2093,7 +2441,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublicBundleCISubscriptionsResource"
+                  "$ref": "#/components/schemas/CIBundleSubscriptionsResource"
                 }
               }
             },
@@ -2205,7 +2553,7 @@
         }
       ]
     },
-    "/bundles/{id-bundle}/payment-service-providers/{psp-tax-code}/subscriptions/{ci-tax-code}/detail": {
+    "/bundles/{id-bundle}/payment-service-providers/{psp-tax-code}/subscriptions/{ci-tax-code}": {
       "get": {
         "description": "Internal | External | Synchronous | Authorization | Authentication | TPS | Idempotency | Stateless | Read/Write Intense | Cacheable\n-|-|-|-|-|-|-|-|-|-\nY | N | Y | JWT | JWT | 1.0/sec | Y | Y | Read | N\n",
         "operationId": "getPublicBundleCISubscriptionsDetail",
@@ -2256,7 +2604,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublicBundleCISubscriptionsDetail"
+                  "$ref": "#/components/schemas/CIBundleSubscriptionsDetail"
                 }
               }
             },
@@ -9758,6 +10106,44 @@
           }
         }
       },
+      "CIBundleSubscriptionsDetail": {
+        "type": "object",
+        "properties": {
+          "bundle_offer_id": {
+            "type": "string",
+            "description": "Public bundle offer id"
+          },
+          "bundle_request_id": {
+            "type": "string",
+            "description": "Public bundle request id"
+          },
+          "ci_bundle_fee_list": {
+            "type": "array",
+            "description": "Creditor Institution's fees details",
+            "items": {
+              "$ref": "#/components/schemas/CIBundleFee"
+            }
+          },
+          "ci_bundle_id": {
+            "type": "string",
+            "description": "Subscription's id of a creditor institution to a public bundle"
+          }
+        }
+      },
+      "CIBundleSubscriptionsResource": {
+        "type": "object",
+        "properties": {
+          "creditor_institutions_subscriptions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CISubscriptionInfo"
+            }
+          },
+          "page_info": {
+            "$ref": "#/components/schemas/PageInfo"
+          }
+        }
+      },
       "CIBundlesResource": {
         "type": "object",
         "properties": {
@@ -11761,40 +12147,6 @@
           }
         },
         "description": "Payment Service Provider (PSP) specific data"
-      },
-      "PublicBundleCISubscriptionsDetail": {
-        "type": "object",
-        "properties": {
-          "bundle_request_id": {
-            "type": "string",
-            "description": "Public bundle request id"
-          },
-          "ci_bundle_fee_list": {
-            "type": "array",
-            "description": "Creditor Institution's fees details",
-            "items": {
-              "$ref": "#/components/schemas/CIBundleFee"
-            }
-          },
-          "ci_bundle_id": {
-            "type": "string",
-            "description": "Subscription's id of a creditor institution to a public bundle"
-          }
-        }
-      },
-      "PublicBundleCISubscriptionsResource": {
-        "type": "object",
-        "properties": {
-          "creditor_institutions_subscriptions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CISubscriptionInfo"
-            }
-          },
-          "page_info": {
-            "$ref": "#/components/schemas/PageInfo"
-          }
-        }
       },
       "PublicBundleRequest": {
         "required": [

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -11462,7 +11462,7 @@
             "type": "string",
             "description": "Poste auth code"
           },
-          "posteNane": {
+          "posteName": {
             "type": "string",
             "description": "Poste name"
           },

--- a/src/main/java/it/pagopa/selfcare/pagopa/backoffice/client/GecClient.java
+++ b/src/main/java/it/pagopa/selfcare/pagopa/backoffice/client/GecClient.java
@@ -139,7 +139,7 @@ public interface GecClient {
     @GetMapping(value = "/psps/{psp-code}/bundles/{id-bundle}/creditorInstitutions")
     @ResponseBody
     @Valid
-    BundleCreditorInstitutionResource getPublicBundleSubscriptionByPSP(
+    BundleCreditorInstitutionResource getBundleSubscriptionByPSP(
             @PathVariable("psp-code") String pspCode,
             @PathVariable("id-bundle") String idBundle,
             @RequestParam(name = "ciFiscalCode", required = false) String ciTaxCode,
@@ -150,7 +150,7 @@ public interface GecClient {
     @GetMapping(value = "/psps/{psp-code}/bundles/{id-bundle}/creditorInstitutions/{ci-tax-code}")
     @ResponseBody
     @Valid
-    CiBundleDetails getPublicBundleSubscriptionDetailByPSP(
+    CiBundleDetails getBundleSubscriptionDetailByPSP(
             @PathVariable("psp-code") String pspCode,
             @PathVariable("ci-tax-code") String ciTaxCode,
             @PathVariable("id-bundle") String idBundle

--- a/src/main/java/it/pagopa/selfcare/pagopa/backoffice/client/GecClient.java
+++ b/src/main/java/it/pagopa/selfcare/pagopa/backoffice/client/GecClient.java
@@ -130,7 +130,7 @@ public interface GecClient {
     @Valid
     BundleOffers getPrivateBundleOffersByPSP(
             @PathVariable("psp-code") String pspCode,
-            @RequestParam(name = "ciFiscalCode", required = false) String ciTaxCode,
+            @RequestParam(required = false) String ciTaxCode,
             @RequestParam(required = false) String idBundle,
             @RequestParam(required = false) Integer limit,
             @RequestParam(required = false) Integer page

--- a/src/main/java/it/pagopa/selfcare/pagopa/backoffice/client/GecClient.java
+++ b/src/main/java/it/pagopa/selfcare/pagopa/backoffice/client/GecClient.java
@@ -125,6 +125,17 @@ public interface GecClient {
             @RequestParam(required = false) Integer page
     );
 
+    @GetMapping(value = "/psps/{psp-code}/offers")
+    @ResponseBody
+    @Valid
+    BundleOffers getPrivateBundleOffersByPSP(
+            @PathVariable("psp-code") String pspCode,
+            @RequestParam(name = "ciFiscalCode", required = false) String ciTaxCode,
+            @RequestParam(required = false) String idBundle,
+            @RequestParam(required = false) Integer limit,
+            @RequestParam(required = false) Integer page
+    );
+
     @GetMapping(value = "/psps/{psp-code}/bundles/{id-bundle}/creditorInstitutions")
     @ResponseBody
     @Valid

--- a/src/main/java/it/pagopa/selfcare/pagopa/backoffice/controller/CommissionBundleController.java
+++ b/src/main/java/it/pagopa/selfcare/pagopa/backoffice/controller/CommissionBundleController.java
@@ -222,7 +222,7 @@ public class CommissionBundleController {
      *
      * @param idBundle   the id of the public/private bundle
      * @param pspTaxCode the payment service provider's tax code
-     * @param bundleType the type of the bundle
+     * @param bundleType the type of the bundle (Required only for subscription with status {@link BundleSubscriptionStatus#WAITING}
      * @param status     the status of the subscription
      * @param ciTaxCode  the creditor institution's tax code
      * @param limit      the size of the page
@@ -239,12 +239,12 @@ public class CommissionBundleController {
             @ApiResponse(responseCode = "429", description = "Too many requests", content = @Content(schema = @Schema())),
             @ApiResponse(responseCode = "500", description = "Service unavailable", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemJson.class)))
     })
-    @Operation(summary = "Get a paginated list of creditor institution's subscriptions to a public bundle of a PSP", security = {@SecurityRequirement(name = "JWT")})
+    @Operation(summary = "Get a paginated list of creditor institution's subscriptions to a public/private bundle of a PSP", security = {@SecurityRequirement(name = "JWT")})
     @OpenApiTableMetadata(readWriteIntense = OpenApiTableMetadata.ReadWrite.READ)
     public CIBundleSubscriptionsResource getBundleCISubscriptions(
             @Parameter(description = "Commission bundle's id") @PathVariable("id-bundle") String idBundle,
             @Parameter(description = "Payment Service Provider's tax code") @PathVariable("psp-tax-code") String pspTaxCode,
-            @Parameter(description = "Commission bundle's type") @RequestParam(required = false) BundleType bundleType,
+            @Parameter(description = "Commission bundle's type (Required only for subscription with status WAITING") @RequestParam(required = false) BundleType bundleType,
             @Parameter(description = "Subscription status") @RequestParam BundleSubscriptionStatus status,
             @Parameter(description = "Creditor Institution's tax code, used for filtering results") @RequestParam(required = false) String ciTaxCode,
             @Parameter(description = "Number of elements in one page") @RequestParam(required = false, defaultValue = "50") Integer limit,
@@ -262,7 +262,7 @@ public class CommissionBundleController {
      * @param idBundle   the id of the public/private bundle
      * @param pspTaxCode the payment service provider's tax code
      * @param ciTaxCode  the creditor institution's tax code
-     * @param bundleType the type of the bundle
+     * @param bundleType the type of the bundle (Required only for subscription with status {@link BundleSubscriptionStatus#WAITING}
      * @param status     the status of the subscription
      * @return the detail of a creditor institution's subscription
      */
@@ -282,7 +282,7 @@ public class CommissionBundleController {
             @Parameter(description = "Commission bundle's id") @PathVariable("id-bundle") String idBundle,
             @Parameter(description = "Payment Service Provider's tax code") @PathVariable("psp-tax-code") String pspTaxCode,
             @Parameter(description = "Creditor institution's tax code") @PathVariable("ci-tax-code") String ciTaxCode,
-            @Parameter(description = "Commission bundle's type") @RequestParam(required = false) BundleType bundleType,
+            @Parameter(description = "Commission bundle's type (Required only for subscription with status WAITING") @RequestParam(required = false) BundleType bundleType,
             @Parameter(description = "Subscription status") @RequestParam BundleSubscriptionStatus status
     ) {
         if (BundleSubscriptionStatus.ACCEPTED.equals(status)) {

--- a/src/main/java/it/pagopa/selfcare/pagopa/backoffice/controller/CommissionBundleController.java
+++ b/src/main/java/it/pagopa/selfcare/pagopa/backoffice/controller/CommissionBundleController.java
@@ -10,12 +10,12 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import it.pagopa.selfcare.pagopa.backoffice.model.ProblemJson;
 import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.BundlePaymentTypes;
+import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.BundleSubscriptionStatus;
+import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.CIBundleSubscriptionsDetail;
+import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.CIBundleSubscriptionsResource;
 import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.CIBundlesResource;
 import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.PSPBundleResource;
 import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.PSPBundlesResource;
-import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.PublicBundleCISubscriptionsDetail;
-import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.PublicBundleCISubscriptionsResource;
-import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.PublicBundleSubscriptionStatus;
 import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.Touchpoints;
 import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.client.BundleCreateResponse;
 import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.client.BundleRequest;
@@ -74,7 +74,7 @@ public class CommissionBundleController {
             @Parameter(description = "Number of elements in one page") @RequestParam(required = false, defaultValue = "50") Integer limit,
             @Parameter(description = "Page number") @RequestParam(required = false, defaultValue = "0") @Min(0) Integer page
     ) {
-        return commissionBundleService.getCIBundles(bundleType, ciTaxCode, name, limit, page);
+        return this.commissionBundleService.getCIBundles(bundleType, ciTaxCode, name, limit, page);
     }
 
     @GetMapping("/payment-types")
@@ -85,7 +85,7 @@ public class CommissionBundleController {
             @Parameter(description = "Number of elements on one page. Default = 50") @RequestParam(required = false, defaultValue = "50") Integer limit,
             @Parameter(description = "Page number. Page value starts from 0") @RequestParam(required = false, defaultValue = "0") Integer page
     ) {
-        return commissionBundleService.getBundlesPaymentTypes(limit, page);
+        return this.commissionBundleService.getBundlesPaymentTypes(limit, page);
     }
 
     @GetMapping("/touchpoints")
@@ -96,7 +96,7 @@ public class CommissionBundleController {
             @Parameter(description = "Number of elements on one page. Default = 10") @RequestParam(required = false, defaultValue = "10") Integer limit,
             @Parameter(description = "Page number. Page value starts from 0") @RequestParam(required = false, defaultValue = "0") Integer page
     ) {
-        return commissionBundleService.getTouchpoints(limit, page);
+        return this.commissionBundleService.getTouchpoints(limit, page);
     }
 
     @GetMapping("/payment-service-providers/{psp-tax-code}")
@@ -110,7 +110,7 @@ public class CommissionBundleController {
             @Parameter(description = "Tax code of the payment service provider") @PathVariable("psp-tax-code") String pspTaxCode,
             @Parameter(description = "Commission bundle's name") @RequestParam(required = false) String name
     ) {
-        return commissionBundleService.getBundlesByPSP(pspTaxCode, bundleType, name, limit, page);
+        return this.commissionBundleService.getBundlesByPSP(pspTaxCode, bundleType, name, limit, page);
     }
 
     @PostMapping(value = "/payment-service-providers/{psp-tax-code}", consumes = {MediaType.APPLICATION_JSON_VALUE}, produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -129,7 +129,7 @@ public class CommissionBundleController {
             @Parameter(description = "Tax code of the payment service provider") @PathVariable("psp-tax-code") String pspTaxCode,
             @Parameter(description = "Commission bundle related to PSP to be created") @RequestBody @NotNull BundleRequest bundleRequest
     ) {
-        return commissionBundleService.createPSPBundle(pspTaxCode, bundleRequest);
+        return this.commissionBundleService.createPSPBundle(pspTaxCode, bundleRequest);
     }
 
     @GetMapping(value = "/{id-bundle}/payment-service-providers/{psp-tax-code}")
@@ -140,7 +140,7 @@ public class CommissionBundleController {
             @Parameter(description = "Tax code of the payment service provider") @PathVariable("psp-tax-code") String pspTaxCode,
             @Parameter(description = "Commission bundle's id") @PathVariable("id-bundle") String idBundle
     ) {
-        return commissionBundleService.getBundleDetailByPSP(pspTaxCode, idBundle);
+        return this.commissionBundleService.getBundleDetailByPSP(pspTaxCode, idBundle);
     }
 
     @PutMapping(value = "/{id-bundle}/payment-service-providers/{psp-tax-code}")
@@ -160,7 +160,7 @@ public class CommissionBundleController {
             @Parameter(description = "Commission bundle's id") @PathVariable("id-bundle") String idBundle,
             @Parameter(description = "Commission bundle related to PSP to be updated") @RequestBody @NotNull BundleRequest bundle
     ) {
-        commissionBundleService.updatePSPBundle(pspTaxCode, idBundle, bundle);
+        this.commissionBundleService.updatePSPBundle(pspTaxCode, idBundle, bundle);
     }
 
     @DeleteMapping(value = "/{id-bundle}/payment-service-providers/{psp-tax-code}")
@@ -171,7 +171,7 @@ public class CommissionBundleController {
             @Parameter(description = "Tax code of the payment service provider") @PathVariable("psp-tax-code") String pspTaxCode,
             @Parameter(description = "Commission bundle's id") @PathVariable("id-bundle") String idBundle
     ) {
-        commissionBundleService.deletePSPBundle(pspTaxCode, idBundle);
+        this.commissionBundleService.deletePSPBundle(pspTaxCode, idBundle);
     }
 
     /**
@@ -192,7 +192,7 @@ public class CommissionBundleController {
             @Parameter(description = "Creditor institution's tax code") @RequestParam String ciTaxCode,
             @Parameter(description = "Bundle's name") @RequestParam String bundleName
     ) {
-        commissionBundleService.acceptPublicBundleSubscriptionsByPSP(pspTaxCode, bundleRequestId, ciTaxCode, bundleName);
+        this.commissionBundleService.acceptPublicBundleSubscriptionsByPSP(pspTaxCode, bundleRequestId, ciTaxCode, bundleName);
     }
 
 
@@ -214,7 +214,7 @@ public class CommissionBundleController {
             @Parameter(description = "Creditor institution's tax code") @RequestParam String ciTaxCode,
             @Parameter(description = "Bundle's name") @RequestParam String bundleName
     ) {
-        commissionBundleService.rejectPublicBundleSubscriptionByPSP(pspTaxCode, bundleRequestId, ciTaxCode, bundleName);
+        this.commissionBundleService.rejectPublicBundleSubscriptionByPSP(pspTaxCode, bundleRequestId, ciTaxCode, bundleName);
     }
 
     /**
@@ -231,7 +231,7 @@ public class CommissionBundleController {
     @GetMapping("/{id-bundle}/payment-service-providers/{psp-tax-code}/subscriptions")
     @ResponseStatus(HttpStatus.OK)
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = PublicBundleCISubscriptionsResource.class))),
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = CIBundleSubscriptionsResource.class))),
             @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemJson.class))),
             @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema())),
             @ApiResponse(responseCode = "404", description = "Not found", content = @Content(schema = @Schema(implementation = ProblemJson.class))),
@@ -240,15 +240,15 @@ public class CommissionBundleController {
     })
     @Operation(summary = "Get a paginated list of creditor institution's subscriptions to a public bundle of a PSP", security = {@SecurityRequirement(name = "JWT")})
     @OpenApiTableMetadata(readWriteIntense = OpenApiTableMetadata.ReadWrite.READ)
-    public PublicBundleCISubscriptionsResource getPublicBundleCISubscriptions(
+    public CIBundleSubscriptionsResource getPublicBundleCISubscriptions(
             @Parameter(description = "Commission bundle's id") @PathVariable("id-bundle") String idBundle,
             @Parameter(description = "Payment Service Provider's tax code") @PathVariable("psp-tax-code") String pspTaxCode,
-            @Parameter(description = "Subscription status") @RequestParam PublicBundleSubscriptionStatus status,
+            @Parameter(description = "Subscription status") @RequestParam BundleSubscriptionStatus status,
             @Parameter(description = "Creditor Institution's tax code, used for filtering results") @RequestParam(required = false) String ciTaxCode,
             @Parameter(description = "Number of elements in one page") @RequestParam(required = false, defaultValue = "50") Integer limit,
             @Parameter(description = "Page number") @RequestParam(required = false, defaultValue = "0") Integer page
     ) {
-        return commissionBundleService.getPublicBundleCISubscriptions(idBundle, pspTaxCode, status, ciTaxCode, limit, page);
+        return this.commissionBundleService.getPublicBundleCISubscriptions(idBundle, pspTaxCode, status, ciTaxCode, limit, page);
     }
 
     /**
@@ -263,7 +263,7 @@ public class CommissionBundleController {
     @GetMapping("/{id-bundle}/payment-service-providers/{psp-tax-code}/subscriptions/{ci-tax-code}")
     @ResponseStatus(HttpStatus.OK)
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = PublicBundleCISubscriptionsDetail.class))),
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = CIBundleSubscriptionsDetail.class))),
             @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemJson.class))),
             @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema())),
             @ApiResponse(responseCode = "404", description = "Not found", content = @Content(schema = @Schema(implementation = ProblemJson.class))),
@@ -272,13 +272,13 @@ public class CommissionBundleController {
     })
     @Operation(summary = "Get the detail of a creditor institution's subscription to a public bundle of a PSP", security = {@SecurityRequirement(name = "JWT")})
     @OpenApiTableMetadata(readWriteIntense = OpenApiTableMetadata.ReadWrite.READ)
-    public PublicBundleCISubscriptionsDetail getPublicBundleCISubscriptionsDetail(
+    public CIBundleSubscriptionsDetail getPublicBundleCISubscriptionsDetail(
             @Parameter(description = "Commission bundle's id") @PathVariable("id-bundle") String idBundle,
             @Parameter(description = "Payment Service Provider's tax code") @PathVariable("psp-tax-code") String pspTaxCode,
             @Parameter(description = "Creditor institution's tax code") @PathVariable("ci-tax-code") String ciTaxCode,
-            @Parameter(description = "Subscription status") @RequestParam PublicBundleSubscriptionStatus status
+            @Parameter(description = "Subscription status") @RequestParam BundleSubscriptionStatus status
     ) {
-        return commissionBundleService.getPublicBundleCISubscriptionsDetail(idBundle, pspTaxCode, ciTaxCode, status);
+        return this.commissionBundleService.getPublicBundleCISubscriptionsDetail(idBundle, pspTaxCode, ciTaxCode, status);
     }
 
     /**
@@ -297,14 +297,14 @@ public class CommissionBundleController {
             @Parameter(description = "Creditor Institution's tax code") @PathVariable("ci-tax-code") String ciTaxCode,
             @Parameter(description = "Bundle's name, if present sends an email to notify the Creditor Institution") @RequestParam(required = false) String bundleName
     ) {
-        commissionBundleService.deleteCIBundleSubscription(ciBundleId, ciTaxCode, bundleName);
+        this.commissionBundleService.deleteCIBundleSubscription(ciBundleId, ciTaxCode, bundleName);
     }
 
     /**
      * Remove the creditor institution's subscription request to the specified public bundle
      *
      * @param idBundleRequest Subscription request's id of a creditor institution to a bundle
-     * @param ciTaxCode Creditor Institution's tax code
+     * @param ciTaxCode       Creditor Institution's tax code
      */
     @DeleteMapping(value = "/creditor-institutions/{ci-tax-code}/requests/{bundle-request-id}")
     @ResponseStatus(HttpStatus.OK)
@@ -314,13 +314,13 @@ public class CommissionBundleController {
             @Parameter(description = "Subscription request's id of a creditor institution to a bundle") @PathVariable("bundle-request-id") String idBundleRequest,
             @Parameter(description = "Creditor Institution's tax code") @PathVariable("ci-tax-code") String ciTaxCode
     ) {
-        commissionBundleService.deleteCIBundleRequest(idBundleRequest, ciTaxCode);
+        this.commissionBundleService.deleteCIBundleRequest(idBundleRequest, ciTaxCode);
     }
 
     /**
      * Create the request to subscribe to the specified bundle from the Creditor Institution and notify the Payment Service Provider by email
      *
-     * @param ciTaxCode Creditor Institution's tax code
+     * @param ciTaxCode           Creditor Institution's tax code
      * @param publicBundleRequest Bundle request object with bundle and psp information
      */
     @PostMapping(value = "/creditor-institutions/{ci-tax-code}")
@@ -331,8 +331,8 @@ public class CommissionBundleController {
             @Parameter(description = "Creditor Institution's tax code") @PathVariable("ci-tax-code") String ciTaxCode,
             @Parameter(description = "Bundle's name, if present sends an email to notify the Payment Service Provider") @RequestParam(required = false) String bundleName,
             @RequestBody @NotNull PublicBundleRequest publicBundleRequest
-    ){
-        commissionBundleService.createCIBundleRequest(ciTaxCode, publicBundleRequest, bundleName);
+    ) {
+        this.commissionBundleService.createCIBundleRequest(ciTaxCode, publicBundleRequest, bundleName);
     }
 
     /**
@@ -349,7 +349,7 @@ public class CommissionBundleController {
     @GetMapping("/{id-bundle}/payment-service-providers/{psp-tax-code}/recipients")
     @ResponseStatus(HttpStatus.OK)
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = PublicBundleCISubscriptionsResource.class))),
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = CIBundleSubscriptionsResource.class))),
             @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemJson.class))),
             @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema())),
             @ApiResponse(responseCode = "404", description = "Not found", content = @Content(schema = @Schema(implementation = ProblemJson.class))),
@@ -358,15 +358,15 @@ public class CommissionBundleController {
     })
     @Operation(summary = "Get a paginated list of creditor institution recipients of a private bundle of a PSP", security = {@SecurityRequirement(name = "JWT")})
     @OpenApiTableMetadata(readWriteIntense = OpenApiTableMetadata.ReadWrite.READ)
-    public PublicBundleCISubscriptionsResource getPublicBundleCIRecipients(
+    public CIBundleSubscriptionsResource getPrivateBundleCIRecipients(
             @Parameter(description = "Commission bundle's id") @PathVariable("id-bundle") String idBundle,
             @Parameter(description = "Payment Service Provider's tax code") @PathVariable("psp-tax-code") String pspTaxCode,
-            @Parameter(description = "Subscription status") @RequestParam PublicBundleSubscriptionStatus status,
+            @Parameter(description = "Subscription status") @RequestParam BundleSubscriptionStatus status,
             @Parameter(description = "Creditor Institution's tax code, used for filtering results") @RequestParam(required = false) String ciTaxCode,
             @Parameter(description = "Number of elements in one page") @RequestParam(required = false, defaultValue = "50") Integer limit,
             @Parameter(description = "Page number") @RequestParam(required = false, defaultValue = "0") Integer page
     ) {
-        return commissionBundleService.getPrivateBundleCIRecipients(idBundle, pspTaxCode, status, ciTaxCode, limit, page);
+        return this.commissionBundleService.getPrivateBundleCIRecipients(idBundle, pspTaxCode, status, ciTaxCode, limit, page);
     }
 
     /**
@@ -381,7 +381,7 @@ public class CommissionBundleController {
     @GetMapping("/{id-bundle}/payment-service-providers/{psp-tax-code}/recipients/{ci-tax-code}")
     @ResponseStatus(HttpStatus.OK)
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = PublicBundleCISubscriptionsDetail.class))),
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = CIBundleSubscriptionsDetail.class))),
             @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemJson.class))),
             @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema())),
             @ApiResponse(responseCode = "404", description = "Not found", content = @Content(schema = @Schema(implementation = ProblemJson.class))),
@@ -390,12 +390,12 @@ public class CommissionBundleController {
     })
     @Operation(summary = "Get the detail of a creditor institution recipient of a private bundle of a PSP", security = {@SecurityRequirement(name = "JWT")})
     @OpenApiTableMetadata(readWriteIntense = OpenApiTableMetadata.ReadWrite.READ)
-    public PublicBundleCISubscriptionsDetail getPublicBundleCIRecipientDetail(
+    public CIBundleSubscriptionsDetail getPrivateBundleCIRecipientDetail(
             @Parameter(description = "Commission bundle's id") @PathVariable("id-bundle") String idBundle,
             @Parameter(description = "Payment Service Provider's tax code") @PathVariable("psp-tax-code") String pspTaxCode,
             @Parameter(description = "Creditor institution's tax code") @PathVariable("ci-tax-code") String ciTaxCode,
-            @Parameter(description = "Subscription status") @RequestParam PublicBundleSubscriptionStatus status
+            @Parameter(description = "Subscription status") @RequestParam BundleSubscriptionStatus status
     ) {
-        return commissionBundleService.getPublicBundleCIRecipientDetail(idBundle, pspTaxCode, ciTaxCode, status);
+        return this.commissionBundleService.getPrivateBundleCIRecipientDetail(idBundle, pspTaxCode, ciTaxCode, status);
     }
 }

--- a/src/main/java/it/pagopa/selfcare/pagopa/backoffice/controller/CommissionBundleController.java
+++ b/src/main/java/it/pagopa/selfcare/pagopa/backoffice/controller/CommissionBundleController.java
@@ -260,7 +260,7 @@ public class CommissionBundleController {
      * @param status     the status of the subscription
      * @return the detail of a creditor institution's subscription
      */
-    @GetMapping("/{id-bundle}/payment-service-providers/{psp-tax-code}/subscriptions/{ci-tax-code}/detail")
+    @GetMapping("/{id-bundle}/payment-service-providers/{psp-tax-code}/subscriptions/{ci-tax-code}")
     @ResponseStatus(HttpStatus.OK)
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = PublicBundleCISubscriptionsDetail.class))),
@@ -333,5 +333,69 @@ public class CommissionBundleController {
             @RequestBody @NotNull PublicBundleRequest publicBundleRequest
     ){
         commissionBundleService.createCIBundleRequest(ciTaxCode, publicBundleRequest, bundleName);
+    }
+
+    /**
+     * Retrieve a paginated list of creditor institution recipients of a private bundle of a PSP
+     *
+     * @param idBundle   the id of the private bundle
+     * @param pspTaxCode the payment service provider's tax code
+     * @param status     the status of the offer
+     * @param ciTaxCode  the creditor institution's tax code
+     * @param limit      the size of the page
+     * @param page       the page number
+     * @return a paginated list of creditor institution's info
+     */
+    @GetMapping("/{id-bundle}/payment-service-providers/{psp-tax-code}/recipients")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = PublicBundleCISubscriptionsResource.class))),
+            @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemJson.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema())),
+            @ApiResponse(responseCode = "404", description = "Not found", content = @Content(schema = @Schema(implementation = ProblemJson.class))),
+            @ApiResponse(responseCode = "429", description = "Too many requests", content = @Content(schema = @Schema())),
+            @ApiResponse(responseCode = "500", description = "Service unavailable", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemJson.class)))
+    })
+    @Operation(summary = "Get a paginated list of creditor institution recipients of a private bundle of a PSP", security = {@SecurityRequirement(name = "JWT")})
+    @OpenApiTableMetadata(readWriteIntense = OpenApiTableMetadata.ReadWrite.READ)
+    public PublicBundleCISubscriptionsResource getPublicBundleCIRecipients(
+            @Parameter(description = "Commission bundle's id") @PathVariable("id-bundle") String idBundle,
+            @Parameter(description = "Payment Service Provider's tax code") @PathVariable("psp-tax-code") String pspTaxCode,
+            @Parameter(description = "Subscription status") @RequestParam PublicBundleSubscriptionStatus status,
+            @Parameter(description = "Creditor Institution's tax code, used for filtering results") @RequestParam(required = false) String ciTaxCode,
+            @Parameter(description = "Number of elements in one page") @RequestParam(required = false, defaultValue = "50") Integer limit,
+            @Parameter(description = "Page number") @RequestParam(required = false, defaultValue = "0") Integer page
+    ) {
+        return commissionBundleService.getPrivateBundleCIRecipients(idBundle, pspTaxCode, status, ciTaxCode, limit, page);
+    }
+
+    /**
+     * Retrieve the detail of a creditor institution's recipient of a private bundle of a PSP
+     *
+     * @param idBundle   the id of the private bundle
+     * @param pspTaxCode the payment service provider's tax code
+     * @param ciTaxCode  the creditor institution's tax code
+     * @param status     the status of the subscription
+     * @return the detail of a creditor institution's recipient
+     */
+    @GetMapping("/{id-bundle}/payment-service-providers/{psp-tax-code}/recipients/{ci-tax-code}")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = PublicBundleCISubscriptionsDetail.class))),
+            @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemJson.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema())),
+            @ApiResponse(responseCode = "404", description = "Not found", content = @Content(schema = @Schema(implementation = ProblemJson.class))),
+            @ApiResponse(responseCode = "429", description = "Too many requests", content = @Content(schema = @Schema())),
+            @ApiResponse(responseCode = "500", description = "Service unavailable", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemJson.class)))
+    })
+    @Operation(summary = "Get the detail of a creditor institution recipient of a private bundle of a PSP", security = {@SecurityRequirement(name = "JWT")})
+    @OpenApiTableMetadata(readWriteIntense = OpenApiTableMetadata.ReadWrite.READ)
+    public PublicBundleCISubscriptionsDetail getPublicBundleCIRecipientDetail(
+            @Parameter(description = "Commission bundle's id") @PathVariable("id-bundle") String idBundle,
+            @Parameter(description = "Payment Service Provider's tax code") @PathVariable("psp-tax-code") String pspTaxCode,
+            @Parameter(description = "Creditor institution's tax code") @PathVariable("ci-tax-code") String ciTaxCode,
+            @Parameter(description = "Subscription status") @RequestParam PublicBundleSubscriptionStatus status
+    ) {
+        return commissionBundleService.getPublicBundleCIRecipientDetail(idBundle, pspTaxCode, ciTaxCode, status);
     }
 }

--- a/src/main/java/it/pagopa/selfcare/pagopa/backoffice/exception/AppError.java
+++ b/src/main/java/it/pagopa/selfcare/pagopa/backoffice/exception/AppError.java
@@ -36,6 +36,7 @@ public enum AppError {
     WRAPPER_STATION_INVALID_STATUS(HttpStatus.BAD_REQUEST, "Invalid wrapper Station status", "The requested operation cannot be done. Wrapper station with code %s is not in the expected status"),
     PSP_CODE_NOT_FOUND(HttpStatus.BAD_REQUEST, "Psp Code Not Found", "No psp code found for taxCode %s"),
     BUNDLE_SUBSCRIPTION_BAD_REQUEST(HttpStatus.BAD_REQUEST, "Invalid bundle type requested", "Global bundle do not have bundle subscription"),
+    BUNDLE_SUBSCRIPTION_TYPE_NULL_BAD_REQUEST(HttpStatus.BAD_REQUEST, "Invalid bundle type requested", "Bundle type is required to retrieve bundle subscription"),
 
     STATION_CONFLICT(HttpStatus.CONFLICT, "Station Conflict", "There is a Station not completed."),
 

--- a/src/main/java/it/pagopa/selfcare/pagopa/backoffice/exception/AppError.java
+++ b/src/main/java/it/pagopa/selfcare/pagopa/backoffice/exception/AppError.java
@@ -35,6 +35,7 @@ public enum AppError {
 
     WRAPPER_STATION_INVALID_STATUS(HttpStatus.BAD_REQUEST, "Invalid wrapper Station status", "The requested operation cannot be done. Wrapper station with code %s is not in the expected status"),
     PSP_CODE_NOT_FOUND(HttpStatus.BAD_REQUEST, "Psp Code Not Found", "No psp code found for taxCode %s"),
+    BUNDLE_SUBSCRIPTION_BAD_REQUEST(HttpStatus.BAD_REQUEST, "Invalid bundle type requested", "Global bundle do not have bundle subscription"),
 
     STATION_CONFLICT(HttpStatus.CONFLICT, "Station Conflict", "There is a Station not completed."),
 

--- a/src/main/java/it/pagopa/selfcare/pagopa/backoffice/model/commissionbundle/BundleSubscriptionStatus.java
+++ b/src/main/java/it/pagopa/selfcare/pagopa/backoffice/model/commissionbundle/BundleSubscriptionStatus.java
@@ -3,6 +3,6 @@ package it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle;
 /**
  * Enum that hold public bundle's subscription status
  */
-public enum PublicBundleSubscriptionStatus {
+public enum BundleSubscriptionStatus {
     WAITING, ACCEPTED
 }

--- a/src/main/java/it/pagopa/selfcare/pagopa/backoffice/model/commissionbundle/CIBundleSubscriptionsDetail.java
+++ b/src/main/java/it/pagopa/selfcare/pagopa/backoffice/model/commissionbundle/CIBundleSubscriptionsDetail.java
@@ -16,7 +16,7 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class PublicBundleCISubscriptionsDetail {
+public class CIBundleSubscriptionsDetail {
 
     @JsonProperty("ci_bundle_fee_list")
     @Schema(description = "Creditor Institution's fees details")

--- a/src/main/java/it/pagopa/selfcare/pagopa/backoffice/model/commissionbundle/CIBundleSubscriptionsResource.java
+++ b/src/main/java/it/pagopa/selfcare/pagopa/backoffice/model/commissionbundle/CIBundleSubscriptionsResource.java
@@ -16,7 +16,7 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class PublicBundleCISubscriptionsResource {
+public class CIBundleSubscriptionsResource {
 
     @JsonProperty("creditor_institutions_subscriptions")
     private List<CISubscriptionInfo> ciSubscriptionInfoList;

--- a/src/main/java/it/pagopa/selfcare/pagopa/backoffice/model/commissionbundle/PublicBundleCISubscriptionsDetail.java
+++ b/src/main/java/it/pagopa/selfcare/pagopa/backoffice/model/commissionbundle/PublicBundleCISubscriptionsDetail.java
@@ -26,6 +26,10 @@ public class PublicBundleCISubscriptionsDetail {
     @Schema(description = "Public bundle request id")
     private String bundleRequestId;
 
+    @JsonProperty("bundle_offer_id")
+    @Schema(description = "Public bundle offer id")
+    private String bundleOfferId;
+
     @JsonProperty("ci_bundle_id")
     @Schema(description = "Subscription's id of a creditor institution to a public bundle")
     private String idCIBundle;

--- a/src/main/java/it/pagopa/selfcare/pagopa/backoffice/model/commissionbundle/client/BundleOffers.java
+++ b/src/main/java/it/pagopa/selfcare/pagopa/backoffice/model/commissionbundle/client/BundleOffers.java
@@ -1,0 +1,31 @@
+package it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.client;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import it.pagopa.selfcare.pagopa.backoffice.model.connector.PageInfo;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class BundleOffers {
+
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull
+    @Valid
+    private List<PspBundleOffer> offers;
+
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull
+    @Valid
+    private PageInfo pageInfo;
+}

--- a/src/main/java/it/pagopa/selfcare/pagopa/backoffice/model/commissionbundle/client/PspBundleOffer.java
+++ b/src/main/java/it/pagopa/selfcare/pagopa/backoffice/model/commissionbundle/client/PspBundleOffer.java
@@ -1,0 +1,27 @@
+package it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.client;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class PspBundleOffer {
+
+    @JsonProperty("idBundleOffer")
+    private String id;
+    private String idBundle;
+    private String ciFiscalCode;
+    private LocalDateTime acceptedDate;
+    private LocalDateTime rejectionDate;
+    private LocalDateTime insertedDate;
+
+}

--- a/src/main/java/it/pagopa/selfcare/pagopa/backoffice/service/CommissionBundleService.java
+++ b/src/main/java/it/pagopa/selfcare/pagopa/backoffice/service/CommissionBundleService.java
@@ -252,7 +252,7 @@ public class CommissionBundleService {
             Integer page
     ) {
         if (bundleType == null || BundleType.GLOBAL.equals(bundleType)) {
-            throw new AppException(AppError.BUNDLE_SUBSCRIPTION_BAD_REQUEST);
+            throw new AppException(bundleType == null ? AppError.BUNDLE_SUBSCRIPTION_TYPE_NULL_BAD_REQUEST : AppError.BUNDLE_SUBSCRIPTION_BAD_REQUEST);
         }
 
         String pspCode = this.legacyPspCodeUtil.retrievePspCode(pspTaxCode, true);
@@ -319,7 +319,7 @@ public class CommissionBundleService {
             BundleType bundleType
     ) {
         if (bundleType == null || BundleType.GLOBAL.equals(bundleType)) {
-            throw new AppException(AppError.BUNDLE_SUBSCRIPTION_BAD_REQUEST);
+            throw new AppException(bundleType == null ? AppError.BUNDLE_SUBSCRIPTION_TYPE_NULL_BAD_REQUEST : AppError.BUNDLE_SUBSCRIPTION_BAD_REQUEST);
         }
 
         String pspCode = this.legacyPspCodeUtil.retrievePspCode(pspTaxCode, true);

--- a/src/main/java/it/pagopa/selfcare/pagopa/backoffice/service/CommissionBundleService.java
+++ b/src/main/java/it/pagopa/selfcare/pagopa/backoffice/service/CommissionBundleService.java
@@ -200,8 +200,8 @@ public class CommissionBundleService {
     }
 
     /**
-     * Retrieve a paginated list of creditor institution's info that have requested a subscription ({@link PublicBundleSubscriptionStatus#WAITING})
-     * or are subscribed ({@link PublicBundleSubscriptionStatus#ACCEPTED}) to a public bundle of a PSP
+     * Retrieve a paginated list of creditor institution's info that have requested a subscription ({@link BundleSubscriptionStatus#WAITING})
+     * or are subscribed ({@link BundleSubscriptionStatus#ACCEPTED}) to a public bundle of a PSP
      *
      * @param idBundle   the id of the public bundle
      * @param pspTaxCode the payment service provider's tax code
@@ -211,10 +211,10 @@ public class CommissionBundleService {
      * @param page       the page number
      * @return a paginated list of creditor institution's info
      */
-    public PublicBundleCISubscriptionsResource getPublicBundleCISubscriptions(
+    public CIBundleSubscriptionsResource getPublicBundleCISubscriptions(
             String idBundle,
             String pspTaxCode,
-            PublicBundleSubscriptionStatus status,
+            BundleSubscriptionStatus status,
             String ciTaxCode,
             Integer limit,
             Integer page
@@ -223,9 +223,9 @@ public class CommissionBundleService {
         PageInfo pageInfo;
         List<CISubscriptionInfo> ciSubscriptionInfoList;
 
-        if (status.equals(PublicBundleSubscriptionStatus.ACCEPTED)) {
+        if (status.equals(BundleSubscriptionStatus.ACCEPTED)) {
             BundleCreditorInstitutionResource acceptedSubscription = this.gecClient
-                    .getPublicBundleSubscriptionByPSP(pspCode, idBundle, ciTaxCode, limit, page);
+                    .getBundleSubscriptionByPSP(pspCode, idBundle, ciTaxCode, limit, page);
 
             List<CreditorInstitutionInfo> ciInfoList = getCIInfo(acceptedSubscription);
             ciSubscriptionInfoList = buildCISubscriptionInfoList(ciInfoList, acceptedSubscription);
@@ -239,7 +239,7 @@ public class CommissionBundleService {
             pageInfo = subscriptionRequest.getPageInfo();
         }
 
-        return PublicBundleCISubscriptionsResource.builder()
+        return CIBundleSubscriptionsResource.builder()
                 .ciSubscriptionInfoList(ciSubscriptionInfoList)
                 .pageInfo(pageInfo)
                 .build();
@@ -254,20 +254,20 @@ public class CommissionBundleService {
      * @param status     the status of the subscription
      * @return the detail of a creditor institution's subscription
      */
-    public PublicBundleCISubscriptionsDetail getPublicBundleCISubscriptionsDetail(
+    public CIBundleSubscriptionsDetail getPublicBundleCISubscriptionsDetail(
             String idBundle,
             String pspTaxCode,
             String ciTaxCode,
-            PublicBundleSubscriptionStatus status
+            BundleSubscriptionStatus status
     ) {
         String pspCode = this.legacyPspCodeUtil.retrievePspCode(pspTaxCode, true);
         List<CIBundleFee> ciBundleFeeList = Collections.emptyList();
         String bundleRequestId = null;
         String idCIBundle = null;
 
-        if (status.equals(PublicBundleSubscriptionStatus.ACCEPTED)) {
+        if (status.equals(BundleSubscriptionStatus.ACCEPTED)) {
             CiBundleDetails ciBundleDetails = this.gecClient
-                    .getPublicBundleSubscriptionDetailByPSP(pspCode, ciTaxCode, idBundle);
+                    .getBundleSubscriptionDetailByPSP(pspCode, ciTaxCode, idBundle);
 
             ciBundleFeeList = getCIBundleFeeList(ciBundleDetails.getAttributes());
             idCIBundle = ciBundleDetails.getIdCIBundle();
@@ -283,7 +283,7 @@ public class CommissionBundleService {
             }
         }
 
-        return PublicBundleCISubscriptionsDetail.builder()
+        return CIBundleSubscriptionsDetail.builder()
                 .ciBundleFeeList(ciBundleFeeList)
                 .bundleRequestId(bundleRequestId)
                 .idCIBundle(idCIBundle)
@@ -342,8 +342,8 @@ public class CommissionBundleService {
     }
 
     /**
-     * Retrieve a paginated list of creditor institution's info that have an offer ({@link PublicBundleSubscriptionStatus#WAITING})
-     * or are subscribed ({@link PublicBundleSubscriptionStatus#ACCEPTED}) to a public bundle of a PSP
+     * Retrieve a paginated list of creditor institution's info that have an offer ({@link BundleSubscriptionStatus#WAITING})
+     * or are subscribed ({@link BundleSubscriptionStatus#ACCEPTED}) to a public bundle of a PSP
      *
      * @param idBundle   the id of the public bundle
      * @param pspTaxCode the payment service provider's tax code
@@ -353,10 +353,10 @@ public class CommissionBundleService {
      * @param page       the page number
      * @return a paginated list of creditor institution's info
      */
-    public PublicBundleCISubscriptionsResource getPrivateBundleCIRecipients(
+    public CIBundleSubscriptionsResource getPrivateBundleCIRecipients(
             String idBundle,
             String pspTaxCode,
-            PublicBundleSubscriptionStatus status,
+            BundleSubscriptionStatus status,
             String ciTaxCode,
             Integer limit,
             Integer page
@@ -365,9 +365,9 @@ public class CommissionBundleService {
         PageInfo pageInfo;
         List<CISubscriptionInfo> ciSubscriptionInfoList;
 
-        if (status.equals(PublicBundleSubscriptionStatus.ACCEPTED)) {
+        if (status.equals(BundleSubscriptionStatus.ACCEPTED)) {
             BundleCreditorInstitutionResource acceptedSubscription = this.gecClient
-                    .getPublicBundleSubscriptionByPSP(pspCode, idBundle, ciTaxCode, limit, page);
+                    .getBundleSubscriptionByPSP(pspCode, idBundle, ciTaxCode, limit, page);
 
             List<CreditorInstitutionInfo> ciInfoList = getCIInfo(acceptedSubscription);
             ciSubscriptionInfoList = buildCISubscriptionInfoList(ciInfoList, acceptedSubscription);
@@ -381,7 +381,7 @@ public class CommissionBundleService {
             pageInfo = subscriptionRequest.getPageInfo();
         }
 
-        return PublicBundleCISubscriptionsResource.builder()
+        return CIBundleSubscriptionsResource.builder()
                 .ciSubscriptionInfoList(ciSubscriptionInfoList)
                 .pageInfo(pageInfo)
                 .build();
@@ -396,35 +396,31 @@ public class CommissionBundleService {
      * @param status     the status of the subscription
      * @return the detail of a creditor institution's subscription
      */
-    public PublicBundleCISubscriptionsDetail getPublicBundleCIRecipientDetail(
+    public CIBundleSubscriptionsDetail getPrivateBundleCIRecipientDetail(
             String idBundle,
             String pspTaxCode,
             String ciTaxCode,
-            PublicBundleSubscriptionStatus status
+            BundleSubscriptionStatus status
     ) {
         String pspCode = this.legacyPspCodeUtil.retrievePspCode(pspTaxCode, true);
         List<CIBundleFee> ciBundleFeeList = Collections.emptyList();
         String bundleOfferId = null;
         String idCIBundle = null;
 
-        if (status.equals(PublicBundleSubscriptionStatus.ACCEPTED)) {
-            CiBundleDetails ciBundleDetails = this.gecClient
-                    .getPublicBundleSubscriptionDetailByPSP(pspCode, ciTaxCode, idBundle);
+        if (status.equals(BundleSubscriptionStatus.ACCEPTED)) {
+            CiBundleDetails ciBundleDetails = this.gecClient.getBundleSubscriptionDetailByPSP(pspCode, ciTaxCode, idBundle);
 
             ciBundleFeeList = getCIBundleFeeList(ciBundleDetails.getAttributes());
             idCIBundle = ciBundleDetails.getIdCIBundle();
         } else {
-            BundleOffers subscriptionRequest = this.gecClient
-                    .getPrivateBundleOffersByPSP(pspCode, ciTaxCode, idBundle, 1, 0);
+            BundleOffers offers = this.gecClient.getPrivateBundleOffersByPSP(pspCode, ciTaxCode, idBundle, 1, 0);
 
-            if (!subscriptionRequest.getOffers().isEmpty()) {
-                PspBundleOffer bundleOffer = subscriptionRequest.getOffers().get(0);
-
-                bundleOfferId = bundleOffer.getId();
+            if (!offers.getOffers().isEmpty()) {
+                bundleOfferId = offers.getOffers().get(0).getId();
             }
         }
 
-        return PublicBundleCISubscriptionsDetail.builder()
+        return CIBundleSubscriptionsDetail.builder()
                 .ciBundleFeeList(ciBundleFeeList)
                 .bundleOfferId(bundleOfferId)
                 .idCIBundle(idCIBundle)

--- a/src/test/java/it/pagopa/selfcare/pagopa/backoffice/controller/CommissionBundleControllerTest.java
+++ b/src/test/java/it/pagopa/selfcare/pagopa/backoffice/controller/CommissionBundleControllerTest.java
@@ -2,10 +2,10 @@ package it.pagopa.selfcare.pagopa.backoffice.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.BundlePaymentTypes;
+import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.BundleSubscriptionStatus;
 import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.CIBundlesResource;
 import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.PSPBundleResource;
 import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.PSPBundlesResource;
-import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.BundleSubscriptionStatus;
 import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.Touchpoints;
 import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.client.BundleCreateResponse;
 import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.client.BundleRequest;
@@ -270,7 +270,7 @@ class CommissionBundleControllerTest {
 
     @Test
     void getPublicBundleCISubscriptionsDetail() throws Exception {
-        String url = "/bundles/{id-bundle}/payment-service-providers/{psp-tax-code}/subscriptions/{ci-tax-code}/detail";
+        String url = "/bundles/{id-bundle}/payment-service-providers/{psp-tax-code}/subscriptions/{ci-tax-code}";
         mvc.perform(get(url, BUNDLE_ID, PSP_TAX_CODE, CI_TAX_CODE)
                         .param("status", BundleSubscriptionStatus.ACCEPTED.name())
                         .contentType(MediaType.APPLICATION_JSON_VALUE))
@@ -309,5 +309,28 @@ class CommissionBundleControllerTest {
                         .contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk());
         verify(service).createCIBundleRequest(CI_TAX_CODE, bundleRequest, BUNDLE_NAME);
+    }
+
+
+    @Test
+    void getPrivateBundleCIRecipients() throws Exception {
+        String url = "/bundles/{id-bundle}/payment-service-providers/{psp-tax-code}/recipients";
+        mvc.perform(get(url, BUNDLE_ID, PSP_TAX_CODE)
+                        .param("status", BundleSubscriptionStatus.ACCEPTED.name())
+                        .param("limit", "10")
+                        .param("page", "0")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk());
+        verify(service).getPrivateBundleCIRecipients(BUNDLE_ID, PSP_TAX_CODE, BundleSubscriptionStatus.ACCEPTED, null, 10, 0);
+    }
+
+    @Test
+    void getPrivateBundleCIRecipientDetail() throws Exception {
+        String url = "/bundles/{id-bundle}/payment-service-providers/{psp-tax-code}/recipients/{ci-tax-code}";
+        mvc.perform(get(url, BUNDLE_ID, PSP_TAX_CODE, CI_TAX_CODE)
+                        .param("status", BundleSubscriptionStatus.ACCEPTED.name())
+                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk());
+        verify(service).getPrivateBundleCIRecipientDetail(BUNDLE_ID, PSP_TAX_CODE, CI_TAX_CODE, BundleSubscriptionStatus.ACCEPTED);
     }
 }

--- a/src/test/java/it/pagopa/selfcare/pagopa/backoffice/controller/CommissionBundleControllerTest.java
+++ b/src/test/java/it/pagopa/selfcare/pagopa/backoffice/controller/CommissionBundleControllerTest.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -257,25 +258,55 @@ class CommissionBundleControllerTest {
     }
 
     @Test
-    void getPublicBundleCISubscriptions() throws Exception {
+    void getBundleCISubscriptionsWithAcceptedStatus() throws Exception {
         String url = "/bundles/{id-bundle}/payment-service-providers/{psp-tax-code}/subscriptions";
         mvc.perform(get(url, BUNDLE_ID, PSP_TAX_CODE)
+                        .param("bundleType", BundleType.PUBLIC.name())
                         .param("status", BundleSubscriptionStatus.ACCEPTED.name())
                         .param("limit", "10")
                         .param("page", "0")
                         .contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk());
-        verify(service).getPublicBundleCISubscriptions(BUNDLE_ID, PSP_TAX_CODE, BundleSubscriptionStatus.ACCEPTED, null, 10, 0);
+        verify(service).getAcceptedBundleCISubscriptions(BUNDLE_ID, PSP_TAX_CODE, null, 10, 0);
+        verify(service, never()).getWaitingBundleCISubscriptions(BUNDLE_ID, PSP_TAX_CODE, BundleType.PUBLIC, null, 10, 0);
     }
 
     @Test
-    void getPublicBundleCISubscriptionsDetail() throws Exception {
+    void getBundleCISubscriptionsWithWaitingStatus() throws Exception {
+        String url = "/bundles/{id-bundle}/payment-service-providers/{psp-tax-code}/subscriptions";
+        mvc.perform(get(url, BUNDLE_ID, PSP_TAX_CODE)
+                        .param("bundleType", BundleType.PUBLIC.name())
+                        .param("status", BundleSubscriptionStatus.WAITING.name())
+                        .param("limit", "10")
+                        .param("page", "0")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk());
+        verify(service, never()).getAcceptedBundleCISubscriptions(BUNDLE_ID, PSP_TAX_CODE, null, 10, 0);
+        verify(service).getWaitingBundleCISubscriptions(BUNDLE_ID, PSP_TAX_CODE, BundleType.PUBLIC, null, 10, 0);
+    }
+
+    @Test
+    void getBundleCISubscriptionsDetailWithAcceptedStatus() throws Exception {
         String url = "/bundles/{id-bundle}/payment-service-providers/{psp-tax-code}/subscriptions/{ci-tax-code}";
         mvc.perform(get(url, BUNDLE_ID, PSP_TAX_CODE, CI_TAX_CODE)
+                        .param("bundleType", BundleType.PUBLIC.name())
                         .param("status", BundleSubscriptionStatus.ACCEPTED.name())
                         .contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk());
-        verify(service).getPublicBundleCISubscriptionsDetail(BUNDLE_ID, PSP_TAX_CODE, CI_TAX_CODE, BundleSubscriptionStatus.ACCEPTED);
+        verify(service).getAcceptedBundleCISubscriptionsDetail(BUNDLE_ID, PSP_TAX_CODE, CI_TAX_CODE);
+        verify(service, never()).getWaitingBundleCISubscriptionsDetail(BUNDLE_ID, PSP_TAX_CODE, CI_TAX_CODE, BundleType.PUBLIC);
+    }
+
+    @Test
+    void getBundleCISubscriptionsDetailWithWaitingStatus() throws Exception {
+        String url = "/bundles/{id-bundle}/payment-service-providers/{psp-tax-code}/subscriptions/{ci-tax-code}";
+        mvc.perform(get(url, BUNDLE_ID, PSP_TAX_CODE, CI_TAX_CODE)
+                        .param("bundleType", BundleType.PUBLIC.name())
+                        .param("status", BundleSubscriptionStatus.WAITING.name())
+                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk());
+        verify(service, never()).getAcceptedBundleCISubscriptionsDetail(BUNDLE_ID, PSP_TAX_CODE, CI_TAX_CODE);
+        verify(service).getWaitingBundleCISubscriptionsDetail(BUNDLE_ID, PSP_TAX_CODE, CI_TAX_CODE, BundleType.PUBLIC);
     }
 
     @Test
@@ -309,28 +340,5 @@ class CommissionBundleControllerTest {
                         .contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk());
         verify(service).createCIBundleRequest(CI_TAX_CODE, bundleRequest, BUNDLE_NAME);
-    }
-
-
-    @Test
-    void getPrivateBundleCIRecipients() throws Exception {
-        String url = "/bundles/{id-bundle}/payment-service-providers/{psp-tax-code}/recipients";
-        mvc.perform(get(url, BUNDLE_ID, PSP_TAX_CODE)
-                        .param("status", BundleSubscriptionStatus.ACCEPTED.name())
-                        .param("limit", "10")
-                        .param("page", "0")
-                        .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isOk());
-        verify(service).getPrivateBundleCIRecipients(BUNDLE_ID, PSP_TAX_CODE, BundleSubscriptionStatus.ACCEPTED, null, 10, 0);
-    }
-
-    @Test
-    void getPrivateBundleCIRecipientDetail() throws Exception {
-        String url = "/bundles/{id-bundle}/payment-service-providers/{psp-tax-code}/recipients/{ci-tax-code}";
-        mvc.perform(get(url, BUNDLE_ID, PSP_TAX_CODE, CI_TAX_CODE)
-                        .param("status", BundleSubscriptionStatus.ACCEPTED.name())
-                        .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isOk());
-        verify(service).getPrivateBundleCIRecipientDetail(BUNDLE_ID, PSP_TAX_CODE, CI_TAX_CODE, BundleSubscriptionStatus.ACCEPTED);
     }
 }

--- a/src/test/java/it/pagopa/selfcare/pagopa/backoffice/controller/CommissionBundleControllerTest.java
+++ b/src/test/java/it/pagopa/selfcare/pagopa/backoffice/controller/CommissionBundleControllerTest.java
@@ -2,11 +2,10 @@ package it.pagopa.selfcare.pagopa.backoffice.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.BundlePaymentTypes;
-import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.BundleResource;
 import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.CIBundlesResource;
 import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.PSPBundleResource;
 import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.PSPBundlesResource;
-import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.PublicBundleSubscriptionStatus;
+import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.BundleSubscriptionStatus;
 import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.Touchpoints;
 import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.client.BundleCreateResponse;
 import it.pagopa.selfcare.pagopa.backoffice.model.commissionbundle.client.BundleRequest;
@@ -261,22 +260,22 @@ class CommissionBundleControllerTest {
     void getPublicBundleCISubscriptions() throws Exception {
         String url = "/bundles/{id-bundle}/payment-service-providers/{psp-tax-code}/subscriptions";
         mvc.perform(get(url, BUNDLE_ID, PSP_TAX_CODE)
-                        .param("status", PublicBundleSubscriptionStatus.ACCEPTED.name())
+                        .param("status", BundleSubscriptionStatus.ACCEPTED.name())
                         .param("limit", "10")
                         .param("page", "0")
                         .contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk());
-        verify(service).getPublicBundleCISubscriptions(BUNDLE_ID, PSP_TAX_CODE, PublicBundleSubscriptionStatus.ACCEPTED, null, 10, 0);
+        verify(service).getPublicBundleCISubscriptions(BUNDLE_ID, PSP_TAX_CODE, BundleSubscriptionStatus.ACCEPTED, null, 10, 0);
     }
 
     @Test
     void getPublicBundleCISubscriptionsDetail() throws Exception {
         String url = "/bundles/{id-bundle}/payment-service-providers/{psp-tax-code}/subscriptions/{ci-tax-code}/detail";
         mvc.perform(get(url, BUNDLE_ID, PSP_TAX_CODE, CI_TAX_CODE)
-                        .param("status", PublicBundleSubscriptionStatus.ACCEPTED.name())
+                        .param("status", BundleSubscriptionStatus.ACCEPTED.name())
                         .contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk());
-        verify(service).getPublicBundleCISubscriptionsDetail(BUNDLE_ID, PSP_TAX_CODE, CI_TAX_CODE, PublicBundleSubscriptionStatus.ACCEPTED);
+        verify(service).getPublicBundleCISubscriptionsDetail(BUNDLE_ID, PSP_TAX_CODE, CI_TAX_CODE, BundleSubscriptionStatus.ACCEPTED);
     }
 
     @Test

--- a/src/test/java/it/pagopa/selfcare/pagopa/backoffice/service/CommissionBundleServiceTest.java
+++ b/src/test/java/it/pagopa/selfcare/pagopa/backoffice/service/CommissionBundleServiceTest.java
@@ -357,16 +357,16 @@ class CommissionBundleServiceTest {
         CreditorInstitutionInfo ciInfo = buildCIInfo();
 
         when(legacyPspCodeUtilMock.retrievePspCode(PSP_TAX_CODE, true)).thenReturn(PSP_CODE);
-        when(gecClient.getPublicBundleSubscriptionByPSP(PSP_CODE, ID_BUNDLE, null, LIMIT, PAGE))
+        when(gecClient.getBundleSubscriptionByPSP(PSP_CODE, ID_BUNDLE, null, LIMIT, PAGE))
                 .thenReturn(codeList);
         when(apiConfigSelfcareIntegrationClient.getCreditorInstitutionInfo(Collections.singletonList(CI_TAX_CODE)))
                 .thenReturn(Collections.singletonList(ciInfo));
 
-        PublicBundleCISubscriptionsResource result = assertDoesNotThrow(() -> sut
+        CIBundleSubscriptionsResource result = assertDoesNotThrow(() -> sut
                 .getPublicBundleCISubscriptions(
                         ID_BUNDLE,
                         PSP_TAX_CODE,
-                        PublicBundleSubscriptionStatus.ACCEPTED,
+                        BundleSubscriptionStatus.ACCEPTED,
                         null,
                         LIMIT,
                         PAGE)
@@ -398,16 +398,16 @@ class CommissionBundleServiceTest {
         CreditorInstitutionInfo ciInfo = buildCIInfo();
 
         when(legacyPspCodeUtilMock.retrievePspCode(PSP_TAX_CODE, true)).thenReturn(PSP_CODE);
-        when(gecClient.getPublicBundleSubscriptionByPSP(PSP_CODE, ID_BUNDLE, null, LIMIT, PAGE))
+        when(gecClient.getBundleSubscriptionByPSP(PSP_CODE, ID_BUNDLE, null, LIMIT, PAGE))
                 .thenReturn(codeList);
         when(apiConfigSelfcareIntegrationClient.getCreditorInstitutionInfo(Collections.singletonList(CI_TAX_CODE)))
                 .thenReturn(Collections.singletonList(ciInfo));
 
-        PublicBundleCISubscriptionsResource result = assertDoesNotThrow(() -> sut
+        CIBundleSubscriptionsResource result = assertDoesNotThrow(() -> sut
                 .getPublicBundleCISubscriptions(
                         ID_BUNDLE,
                         PSP_TAX_CODE,
-                        PublicBundleSubscriptionStatus.ACCEPTED,
+                        BundleSubscriptionStatus.ACCEPTED,
                         null,
                         LIMIT,
                         PAGE)
@@ -439,16 +439,16 @@ class CommissionBundleServiceTest {
         CreditorInstitutionInfo ciInfo = buildCIInfo();
 
         when(legacyPspCodeUtilMock.retrievePspCode(PSP_TAX_CODE, true)).thenReturn(PSP_CODE);
-        when(gecClient.getPublicBundleSubscriptionByPSP(PSP_CODE, ID_BUNDLE, null, LIMIT, PAGE))
+        when(gecClient.getBundleSubscriptionByPSP(PSP_CODE, ID_BUNDLE, null, LIMIT, PAGE))
                 .thenReturn(codeList);
         when(apiConfigSelfcareIntegrationClient.getCreditorInstitutionInfo(Collections.singletonList(CI_TAX_CODE)))
                 .thenReturn(Collections.singletonList(ciInfo));
 
-        PublicBundleCISubscriptionsResource result = assertDoesNotThrow(() -> sut
+        CIBundleSubscriptionsResource result = assertDoesNotThrow(() -> sut
                 .getPublicBundleCISubscriptions(
                         ID_BUNDLE,
                         PSP_TAX_CODE,
-                        PublicBundleSubscriptionStatus.ACCEPTED,
+                        BundleSubscriptionStatus.ACCEPTED,
                         null,
                         LIMIT,
                         PAGE)
@@ -486,11 +486,11 @@ class CommissionBundleServiceTest {
         when(apiConfigSelfcareIntegrationClient.getCreditorInstitutionInfo(Collections.singletonList(CI_TAX_CODE)))
                 .thenReturn(Collections.singletonList(ciInfo));
 
-        PublicBundleCISubscriptionsResource result = assertDoesNotThrow(() -> sut
+        CIBundleSubscriptionsResource result = assertDoesNotThrow(() -> sut
                 .getPublicBundleCISubscriptions(
                         ID_BUNDLE,
                         PSP_TAX_CODE,
-                        PublicBundleSubscriptionStatus.WAITING,
+                        BundleSubscriptionStatus.WAITING,
                         null,
                         LIMIT,
                         PAGE)
@@ -516,17 +516,17 @@ class CommissionBundleServiceTest {
                 .build();
 
         when(legacyPspCodeUtilMock.retrievePspCode(PSP_TAX_CODE, true)).thenReturn(PSP_CODE);
-        when(gecClient.getPublicBundleSubscriptionDetailByPSP(PSP_CODE, CI_TAX_CODE, ID_BUNDLE))
+        when(gecClient.getBundleSubscriptionDetailByPSP(PSP_CODE, CI_TAX_CODE, ID_BUNDLE))
                 .thenReturn(bundleDetails);
         when(taxonomyService.getTaxonomiesByCodes(Collections.singletonList(TRANSFER_CATEGORY)))
                 .thenReturn(buildTaxonomyList());
 
-        PublicBundleCISubscriptionsDetail result = assertDoesNotThrow(() -> sut
+        CIBundleSubscriptionsDetail result = assertDoesNotThrow(() -> sut
                 .getPublicBundleCISubscriptionsDetail(
                         ID_BUNDLE,
                         PSP_TAX_CODE,
                         CI_TAX_CODE,
-                        PublicBundleSubscriptionStatus.ACCEPTED)
+                        BundleSubscriptionStatus.ACCEPTED)
         );
 
         assertNotNull(result);
@@ -554,12 +554,12 @@ class CommissionBundleServiceTest {
         when(taxonomyService.getTaxonomiesByCodes(Collections.singletonList(TRANSFER_CATEGORY)))
                 .thenReturn(Collections.singletonList(taxonomy));
 
-        PublicBundleCISubscriptionsDetail result = assertDoesNotThrow(() -> sut
+        CIBundleSubscriptionsDetail result = assertDoesNotThrow(() -> sut
                 .getPublicBundleCISubscriptionsDetail(
                         ID_BUNDLE,
                         PSP_TAX_CODE,
                         CI_TAX_CODE,
-                        PublicBundleSubscriptionStatus.WAITING)
+                        BundleSubscriptionStatus.WAITING)
         );
 
         assertNotNull(result);
@@ -583,12 +583,12 @@ class CommissionBundleServiceTest {
         when(gecClient.getPublicBundleSubscriptionRequestByPSP(PSP_CODE, CI_TAX_CODE, ID_BUNDLE, 1, PAGE))
                 .thenReturn(publicBundleRequests);
 
-        PublicBundleCISubscriptionsDetail result = assertDoesNotThrow(() -> sut
+        CIBundleSubscriptionsDetail result = assertDoesNotThrow(() -> sut
                 .getPublicBundleCISubscriptionsDetail(
                         ID_BUNDLE,
                         PSP_TAX_CODE,
                         CI_TAX_CODE,
-                        PublicBundleSubscriptionStatus.WAITING)
+                        BundleSubscriptionStatus.WAITING)
         );
 
         assertNotNull(result);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- updated the following API to return both public and private bundle subscription
  - `GET /{id-bundle}/payment-service-providers/{psp-tax-code}/subscriptions`
  - `GET /{id-bundle}/payment-service-providers/{psp-tax-code}/subscriptions/{ci-tax-code}`
- updated openapi
- updated unit test

<!--- Describe your changes in detail -->

#### Motivation and Context
[VAS#806](https://pagopa.atlassian.net/browse/VAS-806)
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
